### PR TITLE
Add tariff information to channel available in sites

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2

--- a/amberelectric/api/amber_api.py
+++ b/amberelectric/api/amber_api.py
@@ -16,6 +16,7 @@ from amberelectric.model.range import Range
 from amberelectric.exceptions import ApiException
 
 from ..rest import RESTClientObject
+AMBER_DATE_FORMAT = '%Y-%m-%d'
 
 
 def parse_tariff_information(tariff_information: Optional[object]) -> TariffInformation:
@@ -179,9 +180,9 @@ class AmberApi:
     def get_prices(self, site_id: str, **kwargs) -> List[Union[ActualInterval, CurrentInterval, ForecastInterval]]:
         query_params = {}
         if "end_date" in kwargs:
-            query_params["endDate"] = kwargs.get("end_date").isoformat()
+            query_params["endDate"] = kwargs.get("end_date").strftime(AMBER_DATE_FORMAT)
         if "start_date" in kwargs:
-            query_params["startDate"] = kwargs.get("start_date").isoformat()
+            query_params["startDate"] = kwargs.get("start_date").strftime(AMBER_DATE_FORMAT)
         if "resolution" in kwargs:
             query_params["resolution"] = str(kwargs.get("resolution"))
 
@@ -196,7 +197,7 @@ class AmberApi:
             raise ApiException(response.status, response.reason, response)
 
     def get_usage(self, site_id: str, start_date: date, end_date: date, **kwargs) -> List[Usage]:
-        query_params = {'startDate': start_date.isoformat(), 'endDate': end_date.isoformat()}
+        query_params = {'startDate': start_date.strftime(AMBER_DATE_FORMAT), 'endDate': end_date.strftime(AMBER_DATE_FORMAT)}
         if "resolution" in kwargs:
             query_params["resolution"] = str(kwargs.get("resolution"))
 

--- a/amberelectric/api/amber_api.py
+++ b/amberelectric/api/amber_api.py
@@ -116,7 +116,7 @@ def parse_intervals(intervals: List[object]) -> List[Union[ActualInterval, Curre
 
 
 def parse_channel(channel: object) -> Channel:
-    return Channel(channel['identifier'], channel['type'])
+    return Channel(channel['identifier'], channel['type'], channel['tariff'])
 
 
 def parse_channels(channels: List[object]) -> List[Channel]:

--- a/amberelectric/api/amber_api.py
+++ b/amberelectric/api/amber_api.py
@@ -1,7 +1,8 @@
 from typing import List, Optional, Union
 import json
-import dateutil.parser
+from dateutil import tz, parser
 from datetime import date
+import pandas as pd
 
 from amberelectric.rest import RESTResponse
 from amberelectric.configuration import Configuration
@@ -11,7 +12,7 @@ from amberelectric.model.actual_interval import ActualInterval
 from amberelectric.model.forecast_interval import ForecastInterval
 from amberelectric.model.usage import Usage
 from amberelectric.model.tariff_information import TariffInformation
-from amberelectric.model.channel import Channel
+from amberelectric.model.channel import Channel, ChannelType
 from amberelectric.model.range import Range
 from amberelectric.exceptions import ApiException
 
@@ -47,10 +48,10 @@ def parse_interval(interval: object) -> Union[ActualInterval, CurrentInterval, F
             float(interval['duration']),
             float(interval['spotPerKwh']),
             float(interval['perKwh']),
-            dateutil.parser.isoparse(interval['date']).date(),
-            dateutil.parser.isoparse(interval['nemTime']),
-            dateutil.parser.isoparse(interval['startTime']),
-            dateutil.parser.isoparse(interval['endTime']),
+            parser.isoparse(interval['date']).date(),
+            parser.isoparse(interval['nemTime']),
+            parser.isoparse(interval['startTime']),
+            parser.isoparse(interval['endTime']),
             float(interval['renewables']),
             interval['channelType'],
             interval['spikeStatus'],
@@ -63,10 +64,10 @@ def parse_interval(interval: object) -> Union[ActualInterval, CurrentInterval, F
             float(interval['duration']),
             float(interval['spotPerKwh']),
             float(interval['perKwh']),
-            dateutil.parser.isoparse(interval['date']).date(),
-            dateutil.parser.isoparse(interval['nemTime']),
-            dateutil.parser.isoparse(interval['startTime']),
-            dateutil.parser.isoparse(interval['endTime']),
+            parser.isoparse(interval['date']).date(),
+            parser.isoparse(interval['nemTime']),
+            parser.isoparse(interval['startTime']),
+            parser.isoparse(interval['endTime']),
             float(interval['renewables']),
             interval['channelType'],
             interval['spikeStatus'],
@@ -80,10 +81,10 @@ def parse_interval(interval: object) -> Union[ActualInterval, CurrentInterval, F
             float(interval['duration']),
             float(interval['spotPerKwh']),
             float(interval['perKwh']),
-            dateutil.parser.isoparse(interval['date']).date(),
-            dateutil.parser.isoparse(interval['nemTime']),
-            dateutil.parser.isoparse(interval['startTime']),
-            dateutil.parser.isoparse(interval['endTime']),
+            parser.isoparse(interval['date']).date(),
+            parser.isoparse(interval['nemTime']),
+            parser.isoparse(interval['startTime']),
+            parser.isoparse(interval['endTime']),
             float(interval['renewables']),
             interval['channelType'],
             interval['spikeStatus'],
@@ -96,10 +97,10 @@ def parse_interval(interval: object) -> Union[ActualInterval, CurrentInterval, F
             float(interval['duration']),
             float(interval['spotPerKwh']),
             float(interval['perKwh']),
-            dateutil.parser.isoparse(interval['date']).date(),
-            dateutil.parser.isoparse(interval['nemTime']),
-            dateutil.parser.isoparse(interval['startTime']),
-            dateutil.parser.isoparse(interval['endTime']),
+            parser.isoparse(interval['date']).date(),
+            parser.isoparse(interval['nemTime']),
+            parser.isoparse(interval['startTime']),
+            parser.isoparse(interval['endTime']),
             float(interval['renewables']),
             interval['channelType'],
             interval['spikeStatus'],
@@ -207,3 +208,24 @@ class AmberApi:
             return parse_intervals(json.loads(response.data.decode("utf-8")))
         else:
             raise ApiException(response.status, response.reason, response)
+        
+    def get_usage_dateframe(self, site_id: str, start_date: date, end_date: date, **kwargs):
+        response = self.get_usage(site_id, start_date, end_date, **kwargs)
+        df1 = pd.DataFrame([row.to_dict() for row in response])
+        if len(df1) == 0:
+            raise Exception('No data found for site %s' % site_id)
+        timezone = kwargs.get('timezone', 'Australia/Brisbane')
+        df1['nem_time'] = pd.to_datetime(df1['nem_time']).dt.tz_convert(tz.gettz(timezone))
+        df1.index = df1['nem_time']
+        df1.sort_index(inplace=True)
+        feed_in = df1[df1['channel_type'] == ChannelType.FEED_IN]
+        general = df1[df1['channel_type'] == ChannelType.GENERAL]
+        amber_prices = feed_in.copy()
+        # Rename Price to feed_in_tariff
+        amber_prices.rename(columns={'per_kwh': 'feed_in_tariff'}, inplace=True)
+        amber_prices.rename(columns={'kwh': 'feed_in_kwh'}, inplace=True)
+        amber_prices.rename(columns={'cost': 'feed_in_cost'}, inplace=True)
+        amber_prices['general_tariff'] = general['per_kwh']
+        amber_prices['general_kwh'] = general['kwh']
+        amber_prices['general_cost'] = general['cost']
+        return amber_prices

--- a/amberelectric/model/channel.py
+++ b/amberelectric/model/channel.py
@@ -28,12 +28,13 @@ class Channel(object):
     """Channel type."""
     type: ChannelType
 
-    def __init__(self, identifier: str, type: ChannelType):
+    def __init__(self, identifier: str, type: ChannelType, tariff: str):
         self.identifier = identifier
+        self.tariff = tariff
         self.type = ChannelType.from_str(type)
 
     def __repr__(self) -> str:
         return self.to_str()
 
     def to_str(self):
-        return str({'identifier': self.identifier, 'type': self.type})
+        return str({'identifier': self.identifier, 'type': self.type, 'tariff': self.tariff})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3
+pandas >= 1.1.4

--- a/test/test_amber_api.py
+++ b/test/test_amber_api.py
@@ -42,15 +42,18 @@ def test_sites_success(mocker, configuration):
           "channels": [
             {
               "identifier": "E1",
-              "type": "general"
+              "type": "general",
+              "tariff": "3970"
             },
             {
               "identifier": "E2",
-              "type": "controlledLoad"
+              "type": "controlledLoad",
+              "tariff": "3300"
             },
             {
               "identifier": "B1",
-              "type": "feedIn"
+              "type": "feedIn",
+              "tariff": "9850"
             }
           ]
         }


### PR DESCRIPTION
While waiting for my smart meter, I noticed my cost was more than a friend's. When I dug into this, I found that my site's tariff was higher. This information is available on the site's channel, so I have updated the code so this can also be seen through the Python wrapper to the API.

![image](https://github.com/madpilot/amberelectric.py/assets/22875/6681bdc7-16a7-43fa-8845-17e9a7432868)
 